### PR TITLE
feat: Add command history functionality

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -11,11 +11,21 @@
 #define MAXARGS 64
 #define ARGLEN 64
 #define PROMPT "myshell> "
+#define HISTORY_SIZE 20
 
 // Function declarations
 char* read_cmd(char* prompt, FILE* fp);
 char** tokenize(char* cmdline);
 int execute(char* arglist[]);
-int handle_builtin(char** arglist);  // NEW: Built-in command handler
+int handle_builtin(char** arglist);
+
+// NEW: History function declarations
+void add_to_history(const char* cmdline);
+void print_history();
+int execute_from_history(int n);
+
+// NEW: External declaration of history array
+extern char* history[HISTORY_SIZE];
+extern int history_count;
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -5,10 +5,34 @@ int main() {
     char** arglist;
 
     while ((cmdline = read_cmd(PROMPT, stdin)) != NULL) {
+        // NEW: Handle history re-execution (!n command)
+        if (cmdline[0] == '!') {
+            int hist_num;
+            if (sscanf(cmdline + 1, "%d", &hist_num) == 1) {
+                int hist_index = execute_from_history(hist_num);
+                if (hist_index >= 0) {
+                    // Replace current command with history command
+                    free(cmdline);
+                    cmdline = strdup(history[hist_index]);
+                    printf("%s\n", cmdline); // Echo the command
+                } else {
+                    free(cmdline);
+                    continue; // Skip to next iteration if history command failed
+                }
+            } else {
+                printf("Invalid history command. Use !n where n is history number.\n");
+                free(cmdline);
+                continue;
+            }
+        }
+        
+        // NEW: Add non-empty commands to history (except history commands themselves)
+        if (strlen(cmdline) > 0 && cmdline[0] != '!') {
+            add_to_history(cmdline);
+        }
+        
         if ((arglist = tokenize(cmdline)) != NULL) {
-            // NEW: Check if it's a built-in command before executing
             if (!handle_builtin(arglist)) {
-                // If not built-in, execute as external command
                 execute(arglist);
             }
 


### PR DESCRIPTION
- Implement history storage with array of strings (stores last 20 commands)
- Add history built-in command to display command history with line numbers
- Add nano ./src/main.c command to re-execute commands from history by number
- Handle history command errors (invalid numbers, out of bounds)
- Skip empty commands and consecutive duplicates in history
- Implement FIFO behavior when history is full (remove oldest commands)
- Update help command to include history command
- Fix extern declaration for global history variables